### PR TITLE
fix: 改进第二种绘制多行居中文本的代码

### DIFF
--- a/DrawTextDemo/app/src/main/java/com/yl/drawtext/CustomTextView.java
+++ b/DrawTextDemo/app/src/main/java/com/yl/drawtext/CustomTextView.java
@@ -144,46 +144,19 @@ public class CustomTextView extends View {
         String[] texts = {"A", "B", "C"};
 
         Paint.FontMetrics fontMetrics = paint.getFontMetrics();
-        // top绝对值
-        float top = Math.abs(fontMetrics.top);
-        // ascent绝对值
-        float ascent = Math.abs(fontMetrics.ascent);
-        // descent，正值
-        float descent = fontMetrics.descent;
-        // bottom，正值
-        float bottom = fontMetrics.bottom;
+
+        // 文本高度
+        float textHeight = fontMetrics.bottom - fontMetrics.top;
         // 行数
         int textLines = texts.length;
-        // 文本高度
-        float textHeight = top + bottom;
-        // 文本总高度
-        float textTotalHeight = textHeight * textLines;
-        // 基数
-        float basePosition = (textLines - 1) / 2f;
-
-        for (int i = 0; i < textLines; i++) {
-            // 文本宽度
+        // 中间一行文本的 base line
+        float centerBaseY = -(fontMetrics.ascent + fontMetrics.descent) / 2;
+        for (int i = 0; i < textLines; ++ i) {
             float textWidth = paint.measureText(texts[i]);
-            // 文本baseline在y轴方向的位置
-            float baselineY;
-
-            if (i < basePosition) {
-                // x轴上，值为负
-                // 总高度的/2 - 已绘制的文本高度 - 文本的top值（绝对值）
-                baselineY = -(textTotalHeight / 2 - textHeight * i - top);
-
-            } else if (i > basePosition) {
-                // x轴下，值为正
-                // 总高度的/2 - 未绘制的文本高度 - 文本的bottom值（绝对值）
-                baselineY = textTotalHeight / 2 - textHeight * (textLines - i - 1) - bottom;
-
-            } else {
-                // x轴中，值为正
-                // 计算公式请参考单行文本居中公式
-                baselineY = (ascent - descent) / 2;
-            }
-
-            canvas.drawText(texts[i], -textWidth / 2, baselineY, paint);
+            // 第 i 行文字的 base line = 中间一行的 base line + 偏移
+            // 而偏移等于行号的偏移 * textHeight，行号偏移等于 i 减去中间一行的行号，即减去 (textLines - 1) / 2
+            float baseY = centerBaseY + (i - (textLines - 1) / 2.0f) * textHeight;
+            canvas.drawText(texts[i], -textWidth / 2, baseY, paint);
         }
     }
 


### PR DESCRIPTION
我的计算方式是先计算出最中间一行的 base line，然后依据行号，循环计算各行的 base line。此外，各行的 base line 应该是成等差数列的，而你原来的代码，三行的 baselineY 分别是 -140.18555，51.26953和257.95898，它们并不成等差数列。相对的，我的计算方式各行的 base line 分别是 -147.80273，51.26953 和 250.3418，是成等差数列的。谢谢！